### PR TITLE
Wii U: Make sure to use bcopy/bzero.

### DIFF
--- a/include/PR/os_libc.h
+++ b/include/PR/os_libc.h
@@ -10,6 +10,11 @@
 // macOS libc has them
 #include <strings.h>
 
+#elif defined(__WIIU__)
+
+extern void bcopy(const void *, void *, size_t);
+extern void bzero(void *, size_t);
+
 #elif defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L) || defined(NO_BZERO_BCOPY)
 
 // there's no way that shit's defined, use memcpy/memset


### PR DESCRIPTION
Has been tested as it's used in save file handling, so the game should crash pretty early if it won't work.