### PR TITLE
Implemented analog camera controls on Wii U

### DIFF
--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -220,7 +220,9 @@ static void optvideo_apply(UNUSED struct Option *self, s32 arg) {
 #ifdef BETTERCAMERA
 static struct Option optsCamera[] = {
     DEF_OPT_TOGGLE( optsCameraStr[6], &configEnableCamera ),
+#ifndef TARGET_WII_U
     DEF_OPT_TOGGLE( optsCameraStr[7], &configCameraMouse ),
+#endif
     DEF_OPT_TOGGLE( optsCameraStr[2], &configCameraInvertX ),
     DEF_OPT_TOGGLE( optsCameraStr[3], &configCameraInvertY ),
     DEF_OPT_SCROLL( optsCameraStr[0], &configCameraXSens, 10, 250, 1 ),


### PR DESCRIPTION
This pull request enables functionality of the "Analogue Camera" toggle in the options menu when compiled with `BETTERCAMERA=1`.

For some details, since it is a bit confusing - when compiled with `BETTERCAMERA=1`, by default the camera is actually not analog, just the 4 C buttons mapped to making the camera move in a much more modern way but only at full speed (this is the puppycam mod). When "Analogue Camera" is turned on, it uses the analog stick on player 2's controller as a _true_ analog camera, letting you move it at slower speeds if the stick is only partially held.

The way this is implemented in the sm64 pc port is by using two external variables `rightx` and `righty` as the values of the right stick, which a controller implementation can modify. This pull request hooks into those variables to supply them with values from the gamepad/pro controller/etc.

While I was at it, I also removed the "Mouse Look" menu option since that is not currently supported with this port.

I have tested this pull request with the Wii U gamepad, Wii U Pro controller, Wiimote + nunchuck, and Wiimote + classic controller and they all seem to work as expected. I also tested it without `BETTERCAMERA=1` to make sure that the original camera still works.